### PR TITLE
Update complete to use passport-azure-ad 3.0.x

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,53 +47,41 @@ var log = bunyan.createLogger({
 //   serialize users into and deserialize users out of the session.  Typically,
 //   this will be as simple as storing the user ID when serializing, and finding
 //   the user by ID when deserializing.
-passport.serializeUser(function(user, done) {
-  done(null, user.email);
-});
 
-passport.deserializeUser(function(id, done) {
-  findByEmail(id, function (err, user) {
-    done(err, user);
-  });
-});
 
-// array to hold logged in users
-var users = [];
+// Use the OIDCStrategy within Passport. (Section 2)
 
-var findByEmail = function(email, fn) {
-  for (var i = 0, len = users.length; i < len; i++) {
-    var user = users[i];
-   log.info('we are using user: ', user);
-    if (user.email === email) {
-      return fn(null, user);
-    }
-  }
-  return fn(null, null);
-};
-
-// Use the OIDCStrategy within Passport. (Section 2) 
-// 
-//   Strategies in passport require a `validate` function, which accept
-//   credentials (in this case, an OpenID identifier), and invoke a callback
+//   Strategies in passport require a `validate` function that accepts
+//   credentials (in this case, an OpenID identifier), and invokes a callback
 //   with a user object.
 passport.use(new OIDCStrategy({
-    callbackURL: config.creds.returnURL,
-    realm: config.creds.realm,
-    clientID: config.creds.clientID,
-    clientSecret: config.creds.clientSecret,
-    oidcIssuer: config.creds.issuer,
     identityMetadata: config.creds.identityMetadata,
-    skipUserProfile: config.creds.skipUserProfile,
+    clientID: config.creds.clientID,
     responseType: config.creds.responseType,
-    responseMode: config.creds.responseMode
+    responseMode: config.creds.responseMode,
+    redirectUrl: config.creds.redirectUrl,
+    allowHttpForRedirectUrl: config.creds.allowHttpForRedirectUrl,
+    clientSecret: config.creds.clientSecret,
+    validateIssuer: config.creds.validateIssuer,
+    isB2C: config.creds.isB2C,
+    issuer: config.creds.issuer,
+    passReqToCallback: config.creds.passReqToCallback,
+    scope: config.creds.scope,
+    loggingLevel: config.creds.loggingLevel,
+    loggingNoPII: config.creds.loggingNoPII,
+    nonceLifetime: config.creds.nonceLifetime,
+    nonceMaxAmount: config.creds.nonceMaxAmount,
+    useCookieInsteadOfSession: config.creds.useCookieInsteadOfSession,
+    cookieEncryptionKeys: config.creds.cookieEncryptionKeys,
+    clockSkew: config.creds.clockSkew,
   },
   function(iss, sub, profile, accessToken, refreshToken, done) {
-    if (!profile.email) {
-      return done(new Error("No email found"), null);
+    if (!profile.oid) {
+      return done(new Error("No oid found"), null);
     }
     // asynchronous verification, for effect...
     process.nextTick(function () {
-      findByEmail(profile.email, function(err, user) {
+      findByOid(profile.oid, function(err, user) {
         if (err) {
           return done(err);
         }
@@ -108,12 +96,39 @@ passport.use(new OIDCStrategy({
   }
 ));
 
-
 // configure Express (Section 2)
+// Passport session setup. (Section 2)
+//   To support persistent sign-in sessions, Passport needs to be able to
+//   serialize users into the session and deserialize them out of the session. Typically,
+//   this is done simply by storing the user ID when serializing and finding
+//   the user by ID when deserializing.
+passport.serializeUser(function(user, done) {
+    done(null, user.oid);
+});
+
+passport.deserializeUser(function(id, done) {
+    findByOid(id, function (err, user) {
+        done(err, user);
+    });
+});
+
+// array to hold signed-in users
+var users = [];
+
+var findByEmail = function(email, fn) {
+    for (var i = 0, len = users.length; i < len; i++) {
+        var user = users[i];
+        log.info('we are using user: ', user);
+        if (user.oid === oid) {
+            return fn(null, user);
+        }
+    }
+    return fn(null, null);
+};
+
+// configure Express (section 2)
 
 var app = express();
-
-
 app.configure(function() {
   app.set('views', __dirname + '/views');
   app.set('view engine', 'ejs');
@@ -130,7 +145,7 @@ app.configure(function() {
   app.use(express.static(__dirname + '/../../public'));
 });
 
-//Routes (Section 4)
+//Routes (section 4)
 
 app.get('/', function(req, res){
   res.render('index', { user: req.user });
@@ -140,25 +155,12 @@ app.get('/account', ensureAuthenticated, function(req, res){
   res.render('account', { user: req.user });
 });
 
-app.get('/login',
-  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+app.get('/login', 
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/' }),
   function(req, res) {
     log.info('Login was called in the Sample');
     res.redirect('/');
 });
-
-// GET /auth/openid/return
-//   Use passport.authenticate() as route middleware to authenticate the
-//   request.  If authentication fails, the user will be redirected back to the
-//   login page.  Otherwise, the primary route function function will be called,
-//   which, in this example, will redirect the user to the home page.
-app.get('/auth/openid/return',
-  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
-  function(req, res) {
-    log.info('We received a return from AzureAD.');
-    res.redirect('/');
-  });
-
 
 // POST /auth/openid/return
 //   Use passport.authenticate() as route middleware to authenticate the
@@ -166,30 +168,38 @@ app.get('/auth/openid/return',
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
 app.post('/auth/openid/return',
-  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/' }),
   function(req, res) {
-    log.info('We received a return from AzureAD.');
+    log.info('call post auth return');
     res.redirect('/');
-  });
+  }
+);
 
-app.get('/logout', function(req, res){
-req.session.destroy(function (err) {
-    req.logOut();
-    res.redirect('https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000');
-  });
-
+app.get('/logout', function(req, res) {
+  req.logout();
+  res.redirect('/');
 });
 
-app.listen(3000);
+// Simple route middleware to ensure user is authenticated. (section 4)
 
-
-// Simple route middleware to ensure user is authenticated. (Section 4)
-
-//   Use this route middleware on any resource that needs to be protected.  If
-//   the request is authenticated (typically via a persistent login session),
-//   the request will proceed.  Otherwise, the user will be redirected to the
-//   login page.
+//   Use this route middleware on any resource that needs to be protected. If
+//   the request is authenticated (typically via a persistent sign-in session),
+//   the request proceeds. Otherwise, the user is redirected to the
+//   sign-in page.
 function ensureAuthenticated(req, res, next) {
-  if (req.isAuthenticated()) { return next(); }
-  res.redirect('/login')
+    if (req.isAuthenticated()) { return next(); }
+    res.redirect('/login')
 }
+
+var findByOid = function(oid, fn) {
+  for (var i = 0, len = users.length; i < len; i++) {
+    var user = users[i];
+    log.info('we are using user: ', user);
+    if (user.oid === oid) {
+      return fn(null, user);
+    }
+  }
+  return fn(null, null);
+};
+
+app.listen(3000);

--- a/config.js
+++ b/config.js
@@ -1,12 +1,15 @@
   // Don't commit this file to your public repos. This config is for first-run
   //
- exports.creds = {
- 	returnURL: 'http://localhost:3000/auth/openid/return',
- 	identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
- 	clientID: '<your app id>',
- 	clientSecret: '<your secret>', // if you are doing code or id_token code
- 	skipUserProfile: true, // for AzureAD should be set to true.
- 	responseType: 'id_token code', // for login only flows use id_token. For accessing resources use `id_token code`
- 	responseMode: 'query', // For login only flows we should have token passed back to us in a POST
- 	//scope: ['email', 'profile'] // additional scopes you may wish to pass
- };
+  exports.creds = {
+	redirectUrl: 'http://localhost:3000/auth/openid/return',
+	identityMetadata: 'https://login.microsoftonline.com/higashihidekazu.onmicrosoft.com/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
+	clientID: '<your app id>',
+	clientSecret: '<your secret>', // if you are doing code or id_token code
+	skipUserProfile: true, // for AzureAD should be set to true.
+	responseType: 'id_token code', // for login only flows use id_token. For accessing resources use `id_token code`
+	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
+	passReqToCallback: false,
+	allowHttpForRedirectUrl: true, // HTTPで実行する場合はtrue必須。
+	loggingLevel: 'info'
+	//scope: ['email', 'profile'] // additional scopes you may wish to pass
+};

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
     "name": "passport-azure-ad-login-oidc",
     "version": "0.0.1",
     "dependencies": {
-        "express": "3.x",
-        "ejs": ">= 0.0.0",
-        "ejs-locals": ">= 0.0.0",
-        "restify": "*",
-        "mongoose": "*",
-        "bunyan": "*",
-        "assert-plus": "*",
-        "passport": "*",
-        "passport-azure-ad": "*"
+        "assert-plus": "^1.0.0",
+        "bunyan": "^1.8.12",
+        "ejs": "^2.6.1",
+        "ejs-locals": "^1.0.2",
+        "express": "^3.21.2",
+        "mongoose": "^5.2.5",
+        "passport": "^0.4.0",
+        "passport-azure-ad": "^3.0.12",
+        "restify": "^7.2.1"
     }
 }


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/azure/active-directory/develop/active-directory-devquickstarts-openidconnect-nodejs

I referred to the above document, but the complete branch currently does not correspond to passport-azure-ad 3.0.x, so it will not work with the following error.

`"Invalid value for redirectUrl.The URL must be valid and be https://"`

So, I update complete to use passport-azure-ad 3.0.x.